### PR TITLE
replaceReved not working properly on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function revCollector(opts) {
         for (var key in manifest) {
             var patterns = [ escPathPattern(key) ];
             if (opts.replaceReved) {
-                patterns.push( escPathPattern( (path.dirname(key) === '.' ? '' : closeDirBySep(path.dirname(key)) ) + path.basename(key, path.extname(key)) ) 
+                patterns.push( escPathPattern( (path.dirname(key) === '.' ? '' : key.slice(0, key.lastIndexOf(path.basename(key)))) + path.basename(key, path.extname(key)) ) 
                             + opts.revSuffix 
                             + escPathPattern( path.extname(key) )
                         );


### PR DESCRIPTION
Greetings,

I just jumped from grunt to gulp because it seems to be much faster.
Unfortunately I found this bug in gulp-rev-collector:

``` javascript
{ regexp: /resources\/js\/assets\.js/g, replacement: 'resources/js/assets-6889ae5e.js' }
{ regexp: /resources\/js\\assets-[0-9a-f]{8}-?\.js/g, replacement: 'resources/js/assets-6889ae5e.js' }
```

As you can see the generated regexp-replacement objects do not work the 2nd time (**js\/assets** vs **js\\assets**)
