### PR TITLE
Sorts change regexes by pattern length before applying

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ function revCollector(opts) {
                     patterns.forEach(function (pattern) {
                         changes.push({
                             regexp: new RegExp(  dirRule.dirRX + pattern, 'g' ),
+                            patternLength: (dirRule.dirRX + pattern).length,
                             replacement: _.isFunction(dirRule.dirRpl) 
                                             ? dirRule.dirRpl(manifest[key]) 
                                             : closeDirBySep(dirRule.dirRpl) + manifest[key]
@@ -101,12 +102,16 @@ function revCollector(opts) {
                 patterns.forEach(function (pattern) {
                     changes.push({
                         regexp: new RegExp( pattern, 'g' ),
+                        patternLength: pattern.length,
                         replacement: manifest[key]
                     });
                 });
             }
         }
 
+        // Replace longer patterns first
+        // e.g. match `script.js.map` before `script.js`
+        changes.sort(function(a, b) { return b.patternLength - a.patternLength; });
         mutables.forEach(function (file){
             if (!file.isNull()) {
                 var src = file.contents.toString('utf8');

--- a/test.js
+++ b/test.js
@@ -10,6 +10,11 @@ var imgManifestBody     = '{"image.gif": "image-35c3af8134.gif"}';
 var htmlFileBody        = '<html><head><link rel="stylesheet" href="/css/style.css" /><script src="/js/script1.js"></script><script src="/scripts/script2.js"></script></head><body><img src="cdn/image.gif" /></body></html>';
 var htmlRevedFileBody   = '<html><head><link rel="stylesheet" href="/css/style-af457da8.css" /><script src="/js/script1-ce78a5c3.js"></script><script src="/js/script2.js"></script></head><body></body></html>';
 
+var cssSortManifestBody     = '{"style.css":"style-1d87bebe.css", "style.css.css":"style-ebeb78d1.css.css"}';
+var jsSortManifestBody      = '{"script1.js": "script1-61e0be79.js", "script2.js": "script2-a42f5380.js", "script1.js.js": "script1-98eb0e16.js.js", "script2.js.js": "script2-0835f24a.js.js"}';
+var imgSortManifestBody     = '{"image.gif": "image-35c3af8134.gif", "image.gif.gif": "image-4318fa3c53.gif"}';
+var htmlSortFileBody        = '<html><head><link rel="stylesheet" href="/css/style.css.css" /><script src="/js/script1.js.js"></script><script src="/scripts/script2.js.js"></script></head><body><img src="cdn/image.gif.gif" /></body></html>';
+
 var cssSfxManifestBody     = '{"style.css":"style-1d87bebe-rev.css"}';
 var jsSfxManifestBody      = '{"script1.js": "script1-61e0be79-rev.js", "script2.js": "script2-a42f5380-rev.js"}';
 var htmlSfxRevedFileBody   = '<html><head><link rel="stylesheet" href="/css/style-af457da8-rev.css" /><script src="/js/script1-ce78a5c3-rev.js"></script><script src="/js/script2.js"></script></head><body></body></html>';
@@ -66,6 +71,72 @@ it('should replace links in .html file wo params', function (cb) {
 
         assert(
             /\/scripts\/script2-a42f5380\.js/.test(contents),
+            'The JS#2 file name should be correct replaced'
+        );
+
+        fileCount++;
+    });
+
+    stream.on('end', function() {
+        assert.equal(fileCount, 1, 'Only one file should pass through the stream');
+        cb();
+    });
+
+    stream.end();
+});
+
+it('should match longer rev patterns before shorter ones', function (cb) {
+    var stream = revCollector();
+    var fileCount = 0;
+
+    stream.write(new gutil.File({
+        path: 'rev/css/rev-manifest.json',
+        contents: new Buffer(cssSortManifestBody)
+    }));
+
+    stream.write(new gutil.File({
+        path: 'rev/js/rev-manifest.json',
+        contents: new Buffer(jsSortManifestBody)
+    }));
+
+    stream.write(new gutil.File({
+        path: 'index.html',
+        contents: new Buffer(htmlSortFileBody)
+    }));
+
+    stream.on('data', function (file) {
+        var ext = path.extname(file.path);
+        var contents = file.contents.toString('utf8');
+
+        assert.equal(ext, '.html', 'Only html files should pass through the stream');
+
+        assert(
+            !/style\.css\.css/.test(contents),
+            'The CSS file name should be replaced'
+        );
+
+        assert(
+            /\/css\/style-ebeb78d1\.css\.css/.test(contents),
+            'The CSS file name should be correct replaced'
+        );
+
+        assert(
+            !/script1\.js\.js/.test(contents),
+            'The JS#1 file name should be replaced'
+        );
+
+        assert(
+            /\/js\/script1-98eb0e16\.js\.js/.test(contents),
+            'The JS#1 file name should be correct replaced'
+        );
+
+        assert(
+            !/script2\.js\.js/.test(contents),
+            'The JS#2 file name should be replaced'
+        );
+
+        assert(
+            /\/scripts\/script2-0835f24a\.js\.js/.test(contents),
             'The JS#2 file name should be correct replaced'
         );
 


### PR DESCRIPTION
This ensures that patterns which are supersets of other patterns get applied first.

For example, with the following `manifest.json`:
```json
{
  "src.js":"src-1234abc.js",
  "src.js.map":"src-abc1234.js.map"
}
```

If `src-1234abc.js` has the comment `//# sourceMappingURL=src.js.map`, we would want to replace it with `src-abc1234.js.map`, not `src-1234abc.js.map`, as the current implementation does.