### PR TITLE
Match unquoted and unresolved assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function revCollector(opts) {
                 patterns.forEach(function (pattern) {
                     // without dirReplacements we must leave asset filenames with prefixes in its original state
                     changes.push({
-                        regexp: new RegExp( '([\/\\\\\'"])' + pattern, 'g' ),
+                        regexp: new RegExp( '([\/\\\\\'"\(=])' + pattern, 'g' ),
                         patternLength: pattern.length,
                         replacement: '$1' + manifest[key]
                     });

--- a/test.js
+++ b/test.js
@@ -11,6 +11,8 @@ var imgManifestBody     = '{"image.gif": "image-35c3af8134.gif"}';
 var htmlFileBody        = '<html><head><link rel="stylesheet" href="/css/style.css" /><script src="/js/script1.js"></script><script src="/scripts/script2.js"></script></head><body><img src="cdn/image.gif" /></body></html>';
 var htmlRevedFileBody   = '<html><head><link rel="stylesheet" href="/css/style-af457da8.css" /><script src="/js/script1-ce78a5c3.js"></script><script src="/js/script2.js"></script></head><body></body></html>';
 
+var unresolvedHtmlFileBody = '<html><head><style>body { background-image: url(image.gif); }</style></head><body></body></html>';
+
 var cssSortManifestBody     = '{"style.css":"style-1d87bebe.css", "style.css.css":"style-ebeb78d1.css.css"}';
 var jsSortManifestBody      = '{"script1.js": "script1-61e0be79.js", "script2.js": "script2-a42f5380.js", "script1.js.js": "script1-98eb0e16.js.js", "script2.js.js": "script2-0835f24a.js.js"}';
 var imgSortManifestBody     = '{"image.gif": "image-35c3af8134.gif", "image.gif.gif": "image-4318fa3c53.gif"}';
@@ -97,6 +99,47 @@ it('should replace links in .html file wo params', function (cb) {
         assert(
             /cdn\/image-35c3af8134\.gif/.test(contents),
             'The image file name should be correctly replaced'
+        );
+
+        fileCount++;
+    });
+
+    stream.on('end', function() {
+        assert.equal(fileCount, 1, 'Only one file should pass through the stream');
+        cb();
+    });
+
+    stream.end();
+});
+
+it('should replace asset links without leading slashes', function (cb) {
+    var stream = revCollector();
+    var fileCount = 0;
+
+    stream.write(new gutil.File({
+        path: 'rev/img/rev-manifest.json',
+        contents: new Buffer(imgManifestBody)
+    }));
+
+    stream.write(new gutil.File({
+        path: 'index.html',
+        contents: new Buffer(unresolvedHtmlFileBody)
+    }));
+
+    stream.on('data', function (file) {
+        var ext = path.extname(file.path);
+        var contents = file.contents.toString('utf8');
+
+        assert.equal(ext, '.html', 'Only html files should pass through the stream');
+
+        assert(
+            !/image\.gif/.test(contents),
+            'The image file name should be replaced'
+        );
+
+        assert(
+            /image-35c3af8134\.gif/.test(contents),
+            'The unresolved image file name should be correctly replaced'
         );
 
         fileCount++;

--- a/test.js
+++ b/test.js
@@ -29,7 +29,6 @@ var collectedManifestStandard = {
     'script2.js': 'script2-a42f5380.js'
 };
 
-
 it('should replace links in .html file wo params', function (cb) {
     var stream = revCollector();
     var fileCount = 0;
@@ -42,6 +41,11 @@ it('should replace links in .html file wo params', function (cb) {
     stream.write(new gutil.File({
         path: 'rev/js/rev-manifest.json',
         contents: new Buffer(jsManifestBody)
+    }));
+
+    stream.write(new gutil.File({
+        path: 'rev/img/rev-manifest.json',
+        contents: new Buffer(imgManifestBody)
     }));
 
     stream.write(new gutil.File({
@@ -83,6 +87,16 @@ it('should replace links in .html file wo params', function (cb) {
         assert(
             /\/scripts\/script2-a42f5380\.js/.test(contents),
             'The JS#2 file name should be correct replaced'
+        );
+
+        assert(
+            !/image\.gif/.test(contents),
+            'The image file name should be replaced'
+        );
+
+        assert(
+            /cdn\/image-35c3af8134\.gif/.test(contents),
+            'The image file name should be correctly replaced'
         );
 
         fileCount++;

--- a/test.js
+++ b/test.js
@@ -115,7 +115,6 @@ it('should replace links in .html file wo params', function (cb) {
 
 it('should replace asset links without leading slashes', function (cb) {
     var stream = revCollector();
-    var fileCount = 0;
 
     stream.write(new gutil.File({
         path: 'rev/img/rev-manifest.json',
@@ -128,10 +127,7 @@ it('should replace asset links without leading slashes', function (cb) {
     }));
 
     stream.on('data', function (file) {
-        var ext = path.extname(file.path);
         var contents = file.contents.toString('utf8');
-
-        assert.equal(ext, '.html', 'Only html files should pass through the stream');
 
         assert(
             !/image\.gif/.test(contents),
@@ -142,21 +138,15 @@ it('should replace asset links without leading slashes', function (cb) {
             /image-35c3af8134\.gif/.test(contents),
             'The unresolved image file name should be correctly replaced'
         );
-
-        fileCount++;
     });
 
-    stream.on('end', function() {
-        assert.equal(fileCount, 1, 'Only one file should pass through the stream');
-        cb();
-    });
+    stream.on('end', cb);
 
     stream.end();
 });
 
 it('should replace asset links which are not wrapped in quotes', function (cb) {
     var stream = revCollector();
-    var fileCount = 0;
 
     stream.write(new gutil.File({
         path: 'rev/img/rev-manifest.json',
@@ -169,10 +159,7 @@ it('should replace asset links which are not wrapped in quotes', function (cb) {
     }));
 
     stream.on('data', function (file) {
-        var ext = path.extname(file.path);
         var contents = file.contents.toString('utf8');
-
-        assert.equal(ext, '.html', 'Only html files should pass through the stream');
 
         assert(
             !/image\.gif/.test(contents),
@@ -183,14 +170,9 @@ it('should replace asset links which are not wrapped in quotes', function (cb) {
             /image-35c3af8134\.gif/.test(contents),
             'The unquoted image file name should be correctly replaced'
         );
-
-        fileCount++;
     });
 
-    stream.on('end', function() {
-        assert.equal(fileCount, 1, 'Only one file should pass through the stream');
-        cb();
-    });
+    stream.on('end', cb);
 
     stream.end();
 });


### PR DESCRIPTION
Match and replace revisioned assets even if they do not have leading slashes or quotes. Tests have been added for both cases.

An example use case is how [cssnano](https://github.com/ben-eb/cssnano) [normalizes URLs](http://cssnano.co/optimisations/normalizeUrl/), which transforms `background-image: url("./image.jpg");` into `background-image: url(image.jpg);`. The normalized URL is not currently matched by gulp-rev-collector because it has no leading slash and no leading quote, but it is still valid CSS.

Fixes #31